### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos10_system.j2
+++ b/templates/dellos10_system.j2
@@ -36,7 +36,7 @@ dellos_system:
 {% if dellos_system.hostname is defined and dellos_system.hostname %}
 hostname {{ dellos_system.hostname }}
 {% endif %}
-{% for key,value in dellos_system.iteritems() %}
+{% for key,value in dellos_system.items() %}
   {% if key == "hardware_forwarding" %}
     {% if value %}
 hardware forwarding-table mode {{ value }}

--- a/templates/dellos6_system.j2
+++ b/templates/dellos6_system.j2
@@ -15,7 +15,7 @@ dellos_system:
 {% if dellos_system.hostname is defined and dellos_system.hostname %}
 hostname "{{ dellos_system.hostname }}"
 {% endif %}
-{% for key,value in dellos_system.iteritems() %}
+{% for key,value in dellos_system.items() %}
 
   {% if key == "enable_password" %}
     {% if value  %}

--- a/templates/dellos9_system.j2
+++ b/templates/dellos9_system.j2
@@ -87,7 +87,7 @@ dellos_system:
 hostname {{ dellos_system.hostname }}
 {% endif %}
 {% if dellos_system %}
-{% for key,value in dellos_system.iteritems() %}
+{% for key,value in dellos_system.items() %}
   {% if key == "unique_hostname" %}
     {% if value %}
 feature unique-name


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs